### PR TITLE
Archive old tasks in Todoist

### DIFF
--- a/clean_workspace/__init__.py
+++ b/clean_workspace/__init__.py
@@ -10,6 +10,7 @@ import chrome_bookmarks
 import click
 from ScriptingBridge import SBApplication
 from todoist_api_python.api import TodoistAPI
+from clean_workspace.archive import archive_old_tasks
 
 
 # https://github.com/Doist/todoist-api-python/issues/38
@@ -339,6 +340,11 @@ def _generate_todoist_content(browser_urls):
     return todoist_content
 
 
+@click.group()
+def cli():
+    pass
+
+
 @click.command()
 @click.option("--blacklist-domains", type=click.Path(), default=None)
 @click.option("--blacklist-urls", type=click.Path(), default=None)
@@ -355,7 +361,7 @@ def _generate_todoist_content(browser_urls):
     show_default=True,
     help="project in todoist for all created tasks",
 )
-def main(
+def clean_workspace_command(
     tab_description, blacklist_domains, blacklist_urls, todoist_label, todoist_project
 ):
     if not is_internet_connected():
@@ -396,6 +402,19 @@ def main(
         todoist_project,
         todoist_label,
     )
+
+
+@click.command()
+def archive_old_tasks_command():
+    archive_old_tasks()
+
+
+cli.add_command(clean_workspace_command, name="clean-workspace")
+cli.add_command(archive_old_tasks_command, name="archive-old-tasks")
+
+
+if __name__ == "__main__":
+    cli()
 
 
 def is_internet_connected():

--- a/clean_workspace/archive.py
+++ b/clean_workspace/archive.py
@@ -1,4 +1,22 @@
+import datetime
+import os
+from todoist_api_python.api import TodoistAPI
+
 def archive_old_tasks():
-    # find all old tasks (>1mo) and archive them
-    # optionally only do this when there is not a custom name in the title
-    pass
+    key = os.environ.get("TODOIST_API_KEY", None)
+    assert key is not None
+    api = TodoistAPI(key)
+
+    tasks = api.get_tasks()
+    one_year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
+    archived_content = ""
+
+    for task in tasks:
+        task_date = datetime.datetime.strptime(task.created_at, "%Y-%m-%dT%H:%M:%S.%fZ")
+        if task_date < one_year_ago:
+            task_content = f"# {task_date.strftime('%Y-%m-%d')}\n\n{task.content}"
+            archived_content += task_content + "\n\n"
+            api.close_task(task.id)
+
+    if archived_content:
+        print(archived_content)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,28 @@
+import datetime
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+from clean_workspace.archive import archive_old_tasks
+
+class TestArchiveOldTasks(unittest.TestCase):
+
+    @patch('clean_workspace.archive.TodoistAPI')
+    @patch('clean_workspace.archive.datetime')
+    @patch.dict(os.environ, {'TODOIST_API_KEY': 'test_key'})
+    def test_archive_old_tasks(self, mock_datetime, MockTodoistAPI):
+        mock_api = MockTodoistAPI.return_value
+        mock_task = MagicMock()
+        mock_task.created_at = (datetime.datetime.now() - datetime.timedelta(days=366)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        mock_task.content = "Test Task"
+        mock_task.project_id = 123
+        mock_api.get_tasks.return_value = [mock_task]
+
+        mock_datetime.datetime.now.return_value = datetime.datetime(2023, 1, 1)
+
+        archive_old_tasks()
+
+        mock_api.add_task.assert_called_once_with(content="# 2022-01-01\n\nTest Task", project_id=123)
+        mock_api.close_task.assert_called_once_with(mock_task.id)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Related to #37

Implement archiving of old Todoist tasks and extracting their contents as markdown.

* **`clean_workspace/archive.py`**:
  - Implement `archive_old_tasks` function to find tasks older than 365 days.
  - Extract contents of the task as markdown and output a date header.
  - Archive the task in Todoist and print the archived content.

* **`clean_workspace/__init__.py`**:
  - Import `archive_old_tasks` function.
  - Create a new Click command `archive_old_tasks_command` to call `archive_old_tasks`.
  - Modify the main function to use Click group and add subcommands for `clean_workspace_command` and `archive_old_tasks_command`.

* **`tests/test_archive.py`**:
  - Add tests for `archive_old_tasks` function to verify tasks older than 365 days are archived.
  - Verify contents of the task are extracted as markdown with a date header.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iloveitaly/clean-browser/issues/37?shareId=e60391b0-aeab-444b-a6d4-9a5286d66fb2).